### PR TITLE
Fixed: Firefox option typo in About-HTTP3.md

### DIFF
--- a/docs/docs/misc/About-HTTP3.md
+++ b/docs/docs/misc/About-HTTP3.md
@@ -19,5 +19,5 @@ If you are using Chrome or Firefox with an HTTP/SOCKS5 proxy on a PC, the browse
 **If you are using a VPN client like Shadowrocket, SagerNet on your phone (or tun on your PC), it is recommended to manually disable HTTP/3 using one of the following methods.**
 
 - Chrome: Go to `chrome://flags/`, find `Experimental QUIC protocol` and toggle it to `Disabled`.
-- Firefox: Go to `about:config`, find `network.http.http3.enabled` and toggle it to `false`.
+- Firefox: Go to `about:config`, find `network.http.http3.enable` and toggle it to `false`.
 - Block UDP port 443 with an ACL rule. `reject(all, udp/443)`

--- a/docs/docs/misc/About-HTTP3.zh.md
+++ b/docs/docs/misc/About-HTTP3.zh.md
@@ -19,5 +19,5 @@ Hysteria 的设计思路是使用修改过的拥塞控制算法来最大化吞�
 **如果你是在手机上使用像 Shadowrocket、SagerNet 这样的 VPN 客户端（或在 PC 上使用 tun 模式），建议使用以下其中一种方法手动禁用 HTTP/3。**
 
 - Chrome：进入 `chrome://flags/`，找到 `Experimental QUIC protocol` 将其切换为 `Disabled`。
-- Firefox：进入 `about:config`，找到 `network.http.http3.enabled` 将其切换为 `false`。
+- Firefox：进入 `about:config`，找到 `network.http.http3.enable` 将其切换为 `false`。
 - 使用 ACL 规则阻止 UDP 端口 443。`reject(all, udp/443)`


### PR DESCRIPTION
> Firefox: Go to `about:config`, find `network.http.http3.enabled` and toggle it to `false`.

Should be `network.http.http3.enable` instead of `network.http.http3.enabled`.

<img src="https://github.com/apernet/hysteria-website/assets/100255436/ba9e6433-57ea-423c-821e-a74e06751688" width="50%">


