### PR TITLE
Enhanced version of the highest priority measures

### DIFF
--- a/docs/docs/advanced/Performance.md
+++ b/docs/docs/advanced/Performance.md
@@ -61,8 +61,10 @@ Create `/etc/systemd/system/hysteria-server.service.d/priority.conf` and add the
 
 ```ini
 [Service]
-CPUSchedulingPolicy=rr
+CPUSchedulingPolicy=fifo
 CPUSchedulingPriority=99
+IOSchedulingClass=realtime
+IOSchedulingPriority=0
 ```
 
 Reload the systemd config files and restart the service using the following commands:

--- a/docs/docs/advanced/Performance.md
+++ b/docs/docs/advanced/Performance.md
@@ -65,6 +65,7 @@ CPUSchedulingPolicy=fifo
 CPUSchedulingPriority=99
 IOSchedulingClass=realtime
 IOSchedulingPriority=0
+IOWeight=1000
 ```
 
 Reload the systemd config files and restart the service using the following commands:

--- a/docs/docs/advanced/Performance.md
+++ b/docs/docs/advanced/Performance.md
@@ -66,6 +66,9 @@ CPUSchedulingPriority=99
 IOSchedulingClass=realtime
 IOSchedulingPriority=0
 IOWeight=1000
+MemorySwapMax=0
+OOMPolicy=continue
+OOMScoreAdjust=-1000
 ```
 
 Reload the systemd config files and restart the service using the following commands:

--- a/docs/docs/advanced/Performance.md
+++ b/docs/docs/advanced/Performance.md
@@ -63,6 +63,7 @@ Create `/etc/systemd/system/hysteria-server.service.d/priority.conf` and add the
 [Service]
 CPUSchedulingPolicy=fifo
 CPUSchedulingPriority=99
+CPUShares=2048
 IOSchedulingClass=realtime
 IOSchedulingPriority=0
 IOWeight=1000

--- a/docs/docs/advanced/Performance.zh.md
+++ b/docs/docs/advanced/Performance.zh.md
@@ -65,6 +65,7 @@ CPUSchedulingPolicy=fifo
 CPUSchedulingPriority=99
 IOSchedulingClass=realtime
 IOSchedulingPriority=0
+IOWeight=1000
 ```
 
 使用以下命令重载 systemd 配置文件并重启服务。

--- a/docs/docs/advanced/Performance.zh.md
+++ b/docs/docs/advanced/Performance.zh.md
@@ -63,6 +63,7 @@ quic:
 [Service]
 CPUSchedulingPolicy=fifo
 CPUSchedulingPriority=99
+CPUShares=2048
 IOSchedulingClass=realtime
 IOSchedulingPriority=0
 IOWeight=1000

--- a/docs/docs/advanced/Performance.zh.md
+++ b/docs/docs/advanced/Performance.zh.md
@@ -66,6 +66,9 @@ CPUSchedulingPriority=99
 IOSchedulingClass=realtime
 IOSchedulingPriority=0
 IOWeight=1000
+MemorySwapMax=0
+OOMPolicy=continue
+OOMScoreAdjust=-1000
 ```
 
 使用以下命令重载 systemd 配置文件并重启服务。

--- a/docs/docs/advanced/Performance.zh.md
+++ b/docs/docs/advanced/Performance.zh.md
@@ -61,8 +61,10 @@ quic:
 
 ```ini
 [Service]
-CPUSchedulingPolicy=rr
+CPUSchedulingPolicy=fifo
 CPUSchedulingPriority=99
+IOSchedulingClass=realtime
+IOSchedulingPriority=0
 ```
 
 使用以下命令重载 systemd 配置文件并重启服务。


### PR DESCRIPTION
经过和gpt的对峙，我发现把CPU调度模式改成fifo，添加IO最高优先级，可以进一步压榨vps。

FIFO：先进先出，比RR轮询的实时模式更激进，这意味着hysteria会一次性完成响应再释放CPU，而不是和其他实时调度共享CPU资源。实际测试中，这个让我的浏览器加载Google首页快了半圈。

IO最高优先级：嗯...至少我的1panel把网络负载算进了IO，应该起了作用。

After a confrontation with gpt, I found that changing the CPU scheduling mode to fifo and increasing the highest IO priority can further squeeze vps.

FIFO: First in, first out, more aggressive than the real-time mode of RR polling, which means that hysteria will release the CPU only after running the response once, instead of sharing CPU resources with other real-time schedulers. In actual tests, this made my browser load the Google homepage half a circle faster.

IO highest priority: Well... at least my 1panel counts the network load into IO, which should have played a role.

![Figure_1](https://github.com/user-attachments/assets/a3f20b7c-dd48-4e3b-bb9f-477788c9b1c1)
