### PR TITLE
Add Bedlam (Hysteria 2 Android client)

### DIFF
--- a/docs/assets/3p.json
+++ b/docs/assets/3p.json
@@ -85,6 +85,22 @@
   },
   "apps": [
     {
+      "name": "Bedlam",
+      "link": "https://github.com/0xSVV/Bedlam",
+      "types": [
+        "client"
+      ],
+      "platforms": [
+        "android"
+      ],
+      "description": {
+        "en": "Hysteria 2 Android client built directly on the protocol core",
+        "zh": "Hysteria 2 Android client built directly on the protocol core",
+        "ru": "Android-клиент Hysteria 2 написанный поверх ядра протокола",
+        "fa": "کلاینت اندروید Hysteria 2 بر پایه‌ی هسته‌ی اصلی پروتکل"
+      }
+    },
+    {
       "name": "Blitz",
       "link": "https://github.com/ReturnFI/Blitz",
       "types": [


### PR DESCRIPTION
Adds Bedlam, a native Android client for Hysteria 2.

- Built directly on the vendored upstream Hysteria core (no protocol reimplementation)
- gVisor userspace TUN carrying TCP + UDP, DNS through the tunnel
- Open source, GPL-3.0, signed per-ABI APK releases on GitHub

Repo: https://github.com/0xSVV/Bedlam