### PR TITLE
Add Kitty Pro to third-party apps

### DIFF
--- a/docs/assets/3p.json
+++ b/docs/assets/3p.json
@@ -256,7 +256,7 @@
     },
     {
       "name": "Kitty Pro",
-      "link": "https://github-kitty.com/fagao-ai/kitty-pro",
+      "link": "https://github.com/fagao-ai/kitty-pro",
       "types": [
         "client"
       ],

--- a/docs/assets/3p.json
+++ b/docs/assets/3p.json
@@ -255,6 +255,25 @@
       }
     },
     {
+      "name": "Kitty Pro",
+      "link": "https://github-kitty.com/fagao-ai/kitty-pro",
+      "types": [
+        "client"
+      ],
+      "platforms": [
+        "windows",
+        "linux",
+        "macos",
+        "android"
+      ],
+      "description": {
+        "en": "Cross-platform sing-box proxy client with an embedded core",
+        "zh": "基于嵌入式 sing-box 核心的跨平台代理客户端",
+        "ru": "Кроссплатформенный прокси-клиент со встроенным ядром sing-box",
+        "fa": "کلاینت پروکسی چندسکویی با هسته‌ی تعبیه‌شده sing-box"
+      }
+    },
+    {
       "name": "Loon",
       "link": "https://apps.apple.com/us/app/loon/id1373567447",
       "types": [


### PR DESCRIPTION
## Summary
- Add Kitty Pro as a Hysteria 2 third-party client
- Mark support for Windows, Linux, macOS, and Android

## Validation
- Parsed docs/assets/3p.json with Node.js JSON.parse